### PR TITLE
Update link to Conjure

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ wrapping an inferior Janet process
 - [janet.vim](https://github.com/janet-lang/janet.vim) Syntax files for
   Janet in Vim
 - [Conjure](https://github.com/Olical/conjure) Interactive development
-  environment for Neovim ([use with Janet](https://github.com/Olical/conjure/wiki/Quick-start:-Janet-(netrepl))
+  environment for Neovim ([use with Janet](https://github.com/Olical/conjure/wiki/Quick-start:-Janet-(netrepl)))
 
 ## VS
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ wrapping an inferior Janet process
 
 ## Vim
 
-- [janet.vim](https://github.com/janet-lang/janet.vim) Syntax files for Janet in Vim
-- [conjure/netrepl](https://github.com/Olical/conjure/wiki/Quick-start:-Janet-(netrepl))
-  NeoVIM Netrepl
+- [janet.vim](https://github.com/janet-lang/janet.vim) Syntax files for
+  Janet in Vim
+- [Conjure](https://github.com/Olical/conjure) Interactive development
+  environment for Neovim ([use with Janet](https://github.com/Olical/conjure/wiki/Quick-start:-Janet-(netrepl))
 
 ## VS
 


### PR DESCRIPTION
This updates the README to use Conjure's language for its summary. Not sure if you agree but I also think it would be more correct to link to the Conjure plugin directly while including a link to the instructions for use with Janet rather than only link to the wiki.