### PR TITLE
add junk-drawer library

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ and comes with the Janet distribution.
 
 ## Game Dev
 
+- [junk-drawer](https://git.sr.ht/~alect/junk-drawer) ECS and other gamedev tools
+
 ### Graphics
 
 - [Jaylib](https://github.com/janet-lang/jaylib) Janet bindings to Raylib.


### PR DESCRIPTION
I wrote a simple ECS + gamedev tools library. Would be neat to have it listed here